### PR TITLE
修复原#1.1 中mmap方法问题，修复#4.10 代码逻辑问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ def get_lines(fp):
                 yield m[tmp:i+1].decode()
                 tmp = i+1
         if tmp<i:
-            yield yield m[tmp:i+1].decode()
+            yield m[tmp:i+1].decode()
 
 if __name__=="__main__":
     for i in get_lines("fp_some_huge_file"):

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@
 
     if __name__ == '__main__':
         for e in get_lines():
-            process(e) #处理每一行数据
+            process(e)  # 处理每一行数据
 ```
 现在要处理一个大小为10G的文件，但是内存只有4G，如果在只修改get_lines 函数而其他代码保持不变的情况下，应该如何实现？需要考虑的问题都有那些？
 ```
@@ -474,7 +474,7 @@ New 是真正创建实例对象的方法，所以重写基类的new 方法，以
     foo1 = Foo()
     foo2 = Foo()
 
-    print(foo1 is foo2)# True
+    print(foo1 is foo2)  # True
 ```
 第三种方法：元类，元类是用于创建类对象的类，类对象创建实例对象时一定要调用call方法，因此在调用call时候保证始终只创建一个实例即可，type是python的元类
 ```
@@ -804,7 +804,7 @@ RuntimeError： Queue objects should only be shared between processs through inh
                 q.put(i)
         if __name__ == "__main__":
             print("(%s)start"%os.getpid())
-            q = Manager().Queue()#使用Manager中的Queue
+            q = Manager().Queue()  #使用Manager中的Queue
             po = Pool()
             po.apply_async(wrtier,(q,))
             time.sleep(1)
@@ -890,14 +890,14 @@ RuntimeError： Queue objects should only be shared between processs through inh
         print(’---子线程结束---')
     def main():
         t1 = threading.Thread(target=thread)
-        t1.setDaemon(True)#设置子线程守护主线程
+        t1.setDaemon(True)  # 设置子线程守护主线程
         t1.start()
         print('---主线程结束---')
     
     if __name__ =='__main__':
         main()
-    #执行结果
-    ---主线程结束--- #只有主线程结束，子线程来不及执行就被强制结束
+    # 执行结果
+    ---主线程结束--- # 只有主线程结束，子线程来不及执行就被强制结束
 ```
 三、 join（线程同步)
 join 所完成的工作就是线程同步，即主线程任务结束以后，进入堵塞状态，一直等待所有的子线程结束以后，主线程再终止。

--- a/README.md
+++ b/README.md
@@ -365,12 +365,7 @@ https://stackoverflow.com/questions/30294146/python-fastest-way-to-process-large
 ## 3.4 将字符串 "k:1 |k1:2|k2:3|k3:4"，处理成字典 {k:1,k1:2,...}
 ```
     str1 = "k:1|k1:2|k2:3|k3:4"
-    def str2dict(str1):
-        dict1 = {}
-        for iterms in str1.split('|'):
-            key,value = iterms.split(':')
-            dict1[key] = value
-        return dict1
+    d = {k:int(v) for t in str1.split("|") for k, v in (t.split(":"), )}
 ```
 ## 3.5 请按alist中元素的age由大到小排序
 ```

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ c. 字典 dict 、 集合 set
         pass
     foo1 = Foo()
     foo2 = Foo()
-    print foo1 is foo2 #True
+    print(foo1 is foo2)  # True
 ```
 第二种方法：使用基类
 New 是真正创建实例对象的方法，所以重写基类的new 方法，以此保证创建对象的时候只生成一个实例
@@ -474,7 +474,7 @@ New 是真正创建实例对象的方法，所以重写基类的new 方法，以
     foo1 = Foo()
     foo2 = Foo()
 
-    print foo1 is foo2 #True
+    print(foo1 is foo2)# True
 ```
 第三种方法：元类，元类是用于创建类对象的类，类对象创建实例对象时一定要调用call方法，因此在调用call时候保证始终只创建一个实例即可，type是python的元类
 ```
@@ -490,7 +490,7 @@ New 是真正创建实例对象的方法，所以重写基类的new 方法，以
     
     foo1 = Foo()
     foo2 = Foo()
-    print foo1 is foo2 #True
+    print(foo1 is foo2)  # True
 
 ```
 ## 4.4 反转一个整数，例如-123 --> -321 
@@ -617,7 +617,7 @@ if __name__ == "__main__":
 
 ## 4.2 请手写一个单例
 ```
-    #python2
+    # python2
     class A(object):
         __instance = None
         def __new__(cls,*args,**kwargs):
@@ -713,7 +713,7 @@ yield就是保存当前程序执行状态。你用for循环的时候，每次取
         #启动进程
         p.start()
         time.sleep(1)
-        #1秒钟之后，立刻结束子进程
+        # 1秒钟之后，立刻结束子进程
         p.terminate()
         p.join()
 ```
@@ -761,7 +761,7 @@ Queue.put_nowait(item):相当Queue.put(item,False)
         #启动子进程pr，读取：
         pr.start()
         pr.join()
-        #pr 进程里是死循环，无法等待其结束，只能强行终止:
+        # pr 进程里是死循环，无法等待其结束，只能强行终止:
         print('')
         print('所有数据都写入并且读完')
 ```
@@ -839,7 +839,7 @@ RuntimeError： Queue objects should only be shared between processs through inh
             if mutex.acquire(1):
                 num +=1
                 msg = self.name + 'set num to ' +str(num)
-                print msg
+                print(msg)
                 mutex.release()
     num = 0
     mutex = threading.Lock()
@@ -916,9 +916,9 @@ join 所完成的工作就是线程同步，即主线程任务结束以后，进
         t1 = threading.Thread(target=thread)
         t1.setDaemon(True)
         t1.start()
-        t1.join(timeout=1)#1 线程同步，主线程堵塞1s 然后主线程结束，子线程继续执行
-                          #2 如果不设置timeout参数就等子线程结束主线程再结束
-                          #3 如果设置了setDaemon=True和timeout=1主线程等待1s后会强制杀死子线程，然后主线程结束
+        t1.join(timeout=1)# 1 线程同步，主线程堵塞1s 然后主线程结束，子线程继续执行
+                          # 2 如果不设置timeout参数就等子线程结束主线程再结束
+                          # 3 如果设置了setDaemon=True和timeout=1主线程等待1s后会强制杀死子线程，然后主线程结束
         print('---主线程结束---')
     
     if __name__=='__main___':

--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ def get_lines(fp):
             if char==b"\n":
                 yield m[tmp:i+1].decode()
                 tmp = i+1
+        if tmp<i:
+            yield yield m[tmp:i+1].decode()
 
 if __name__=="__main__":
     for i in get_lines("fp_some_huge_file"):
@@ -670,9 +672,9 @@ if __name__ == "__main__":
     X= (i for i in range(10))
     X是 generator类型
 ## 4.10 请用一行代码 实现将1-N 的整数列表以3为单位分组
-```
-    N =100
-    print ([[x for x in range(1,100)] [i:i+3] for i in range(0,100,3)])
+```python
+    n = 21
+    print([list(range(i,i+3)) for i in range(1,n,3)])
 ```
 ## 4.11 Python中yield的用法》
 yield就是保存当前程序执行状态。你用for循环的时候，每次取一个元素的时候就会计算一次。用yield的函数叫generator,和iterator一样，它的好处是不用一次计算所有元素，而是用一次算一次，可以节省很多空间，generator每次计算需要上一次计算结果，所以用yield,否则一return，上次计算结果就没了


### PR DESCRIPTION
修复原#1.1 中mmap方法缺陷
修复#4.10 代码逻辑问题，原来方法会在每个循环都生成一个0-99的列表，浪费资源
修改print为print()
规范了注释格式
修复[#3.4](https://github.com/kenwoodjw/python_interview_question#34-%E5%B0%86%E5%AD%97%E7%AC%A6%E4%B8%B2-k1-k12k23k34%E5%A4%84%E7%90%86%E6%88%90%E5%AD%97%E5%85%B8-k1k12)原答案啰嗦问题